### PR TITLE
Add missing header <new> for std::bad_alloc.

### DIFF
--- a/src/standard_stack_allocator.cpp
+++ b/src/standard_stack_allocator.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/coroutine/standard_stack_allocator.hpp>
 
+#include <new>
 #include <cstdlib>
 #include <stdexcept>
 


### PR DESCRIPTION
This fixes build with latest Xcode 5.1 on Darwin, which is based on Clang 3.4svn.
