### PR TITLE
Fix context/architectures link in doc

### DIFF
--- a/doc/architectures.qbk
+++ b/doc/architectures.qbk
@@ -8,6 +8,6 @@
 [section:architectures Architectures]
 
 __boost_coroutine__ depends on __boost_context__ which supports these
-[@boost:/libs/context/architectures.html architectures].
+[@boost:/libs/context/doc/html/context/architectures.html architectures].
 
 [endsect]


### PR DESCRIPTION
Change libs/context/architectures.html to libs/context/doc/html/context/architectures.html
