### PR TITLE
Optionally register stacks with valgrind

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,6 +11,9 @@ import toolset ;
 feature.feature segmented-stacks : on : optional propagated composite ;
 feature.compose <segmented-stacks>on : <define>BOOST_USE_SEGMENTED_STACKS ;
 
+feature.feature valgrind : on : optional propagated composite ;
+feature.compose <valgrind>on : <define>BOOST_USE_VALGRIND ;
+
 project boost/coroutine
     : requirements
       <library>/boost/context//boost_context

--- a/include/boost/coroutine/posix/protected_stack_allocator.hpp
+++ b/include/boost/coroutine/posix/protected_stack_allocator.hpp
@@ -14,6 +14,10 @@ extern "C" {
 #include <unistd.h>
 }
 
+#if defined(BOOST_USE_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
 #include <cmath>
 #include <cstddef>
 #include <new>
@@ -70,6 +74,9 @@ struct basic_protected_stack_allocator
 
         ctx.size = size_;
         ctx.sp = static_cast< char * >( limit) + ctx.size;
+#if defined(BOOST_USE_VALGRIND)
+        ctx.valgrind_stack_id = VALGRIND_STACK_REGISTER( ctx.sp, limit);
+#endif
     }
 
     void deallocate( stack_context & ctx)
@@ -78,6 +85,9 @@ struct basic_protected_stack_allocator
         BOOST_ASSERT( traits_type::minimum_size() <= ctx.size);
         BOOST_ASSERT( traits_type::is_unbounded() || ( traits_type::maximum_size() >= ctx.size) );
 
+#if defined(BOOST_USE_VALGRIND)
+        VALGRIND_STACK_DEREGISTER( ctx.valgrind_stack_id);
+#endif
         void * limit = static_cast< char * >( ctx.sp) - ctx.size;
         // conform to POSIX.4 (POSIX.1b-1993, _POSIX_C_SOURCE=199309L)
         ::munmap( limit, ctx.size);

--- a/include/boost/coroutine/stack_context.hpp
+++ b/include/boost/coroutine/stack_context.hpp
@@ -28,9 +28,15 @@ struct stack_context
     std::size_t             size;
     void                *   sp;
     segments_context        segments_ctx;
+#if defined(BOOST_USE_VALGRIND)
+    unsigned                valgrind_stack_id;
+#endif
 
     stack_context() :
         size( 0), sp( 0), segments_ctx()
+#if defined(BOOST_USE_VALGRIND)
+        , valgrind_stack_id( 0)
+#endif
     {}
 };
 #else
@@ -38,9 +44,15 @@ struct stack_context
 {
     std::size_t             size;
     void                *   sp;
+#if defined(BOOST_USE_VALGRIND)
+    unsigned                valgrind_stack_id;
+#endif
 
     stack_context() :
         size( 0), sp( 0)
+#if defined(BOOST_USE_VALGRIND)
+        , valgrind_stack_id( 0)
+#endif
     {}
 };
 #endif

--- a/include/boost/coroutine/standard_stack_allocator.hpp
+++ b/include/boost/coroutine/standard_stack_allocator.hpp
@@ -7,6 +7,10 @@
 #ifndef BOOST_COROUTINES_STANDARD_STACK_ALLOCATOR_H
 #define BOOST_COROUTINES_STANDARD_STACK_ALLOCATOR_H
 
+#if defined(BOOST_USE_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
 #include <cstddef>
 #include <cstdlib>
 #include <new>
@@ -40,6 +44,9 @@ struct basic_standard_stack_allocator
 
         ctx.size = size;
         ctx.sp = static_cast< char * >( limit) + ctx.size;
+#if defined(BOOST_USE_VALGRIND)
+        ctx.valgrind_stack_id = VALGRIND_STACK_REGISTER( ctx.sp, limit);
+#endif
     }
 
     void deallocate( stack_context & ctx)
@@ -47,6 +54,10 @@ struct basic_standard_stack_allocator
         BOOST_ASSERT( ctx.sp);
         BOOST_ASSERT( traits_type::minimum_size() <= ctx.size);
         BOOST_ASSERT( traits_type::is_unbounded() || ( traits_type::maximum_size() >= ctx.size) );
+
+#if defined(BOOST_USE_VALGRIND)
+        VALGRIND_STACK_DEREGISTER( ctx.valgrind_stack_id);
+#endif
 
         void * limit = static_cast< char * >( ctx.sp) - ctx.size;
         std::free( limit);


### PR DESCRIPTION
Running programs that switch stacks under valgrind causes valgrind to spit warnings like the following:

```
==5234== Warning: client switching stacks?  SP change: 0xffefffb90 --> 0x5c4b158
==5234==          to suppress, use: --max-stackframe=68605921848 or greater
```

The `VALGRIND_STACK_[DE]REGISTER` macros tell valgrind to treat the selected memory regions as stack space which suppresses those errors. The macros result in a magic instruction sequence that valgrind recognizes and they don't cause any link dependency.

One concern is the `<valgrind/valgrind.h>` header because to build with `valgrind=on` it has to be externally available. Valgrind's headers have a permissive license so they could in theory be distributed along with boost but I'm not sure about the details of including code from other projects in boost.

Also, I'm not sure how to write tests for this since it's a library project. If there's a mechanism for checking executable output then it should be easy enough to write a trivial program that switches stacks once and checks the valgrind output for the above warning.
