### PR TITLE
Remove duplicated feature 'segmented-stacks'

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,9 +8,6 @@ import feature ;
 import modules ;
 import toolset ;
 
-feature.feature segmented-stacks : on : optional propagated composite ;
-feature.compose <segmented-stacks>on : <define>BOOST_USE_SEGMENTED_STACKS ;
-
 feature.feature valgrind : on : optional propagated composite ;
 feature.compose <valgrind>on : <define>BOOST_USE_VALGRIND ;
 


### PR DESCRIPTION
The feature is already defined in Boost.Contexts Jamfile. It automagically gets picked up by Boost.Build via the dependency on Boost.Context. 
