### PR TITLE
Do not return dangling pointer to exception message

### DIFF
--- a/include/boost/coroutine/exceptions.hpp
+++ b/include/boost/coroutine/exceptions.hpp
@@ -81,9 +81,6 @@ public:
 
     system::error_code const& code() const BOOST_NOEXCEPT
     { return ec_; }
-
-    const char* what() const throw()
-    { return code().message().c_str(); }
 };
 
 class invalid_result : public coroutine_error


### PR DESCRIPTION
The `coroutine_error` class implemented the `what` function in a way that would cause undefined behavior if the returned pointer was ever used, since the object into which it was pointing was a temporary `std::string` that would have already been destroyed before the `what` function returned.