### PR TITLE
Removed BOOST_NOEXCEPT from a method that throws

### DIFF
--- a/include/boost/coroutine/detail/symmetric_coroutine_impl.hpp
+++ b/include/boost/coroutine/detail/symmetric_coroutine_impl.hpp
@@ -392,7 +392,7 @@ public:
         flags_ &= ~flag_running;
     }
 
-    inline void yield() BOOST_NOEXCEPT
+    inline void yield()
     {
         BOOST_ASSERT( is_running() );
         BOOST_ASSERT( ! is_complete() );


### PR DESCRIPTION
It was causing the following to crash:

```
#include <boost/coroutine/all.hpp>
#include <iostream>

void coroutine(boost::coroutines::symmetric_coroutine<void>::yield_type& yield)
{
    yield();
}

int main()
{
    {
        boost::coroutines::symmetric_coroutine<void>::call_type call(coroutine);
        call();
    }
    std::cout << "This won't be printed" << std::endl;

    return 0;
}
```
when compiling with gcc 4.9.0 with the option `-std=c++11`.

I apologise if this is intended behaviour and what happens is caused by misuse of the library from my side.