### PR TITLE
Fix several typos I spotted while reading the documentation

### DIFF
--- a/doc/asymmetric.qbk
+++ b/doc/asymmetric.qbk
@@ -242,7 +242,7 @@ pending __forced_unwind__ exception.]
             // possibly not re-throw pending exception
         }
 
-[important Do not jump from inside a catch block and than re-throw the
+[important Do not jump from inside a catch block and then re-throw the
 exception in another execution context.]
 
 

--- a/doc/stack.qbk
+++ b/doc/stack.qbk
@@ -152,7 +152,7 @@ In contrast to __protected_allocator__ and __standard_allocator__ it creates a
 stack which grows on demand.
 
 [note Segmented stacks are currently only supported by [*gcc] from version
-[*4.7] [*clang] from version [*3.4] onwards. In order to use a
+[*4.7] and [*clang] from version [*3.4] onwards. In order to use a
 __segmented_stack__ __boost_coroutine__ must be built with
 [*toolset=gcc segmented-stacks=on] at b2/bjam command-line. Applications
 must be compiled with compiler-flags

--- a/doc/stack.qbk
+++ b/doc/stack.qbk
@@ -82,7 +82,7 @@ virtual addresses are used.]
 [variablelist
 [[Preconditions:] [`traits_type::minimum_size() <= size` and
 `! traits_type::is_unbounded() && ( traits_type::maximum_size() >= size)`.]]
-[[Effects:] [Allocates memory of at least `size` Bytes and stores a pointer
+[[Effects:] [Allocates memory of at least `size` bytes and stores a pointer
 to the stack and its actual size in `sctx`. Depending
 on the architecture (the stack grows downwards/upwards) the stored address is
 the highest/lowest address of the stack.]]
@@ -126,7 +126,7 @@ end of each stack. The memory is simply managed by `std::malloc()` and
 [variablelist
 [[Preconditions:] [`traits_type::minimum_size() <= size` and
 `! traits_type::is_unbounded() && ( traits_type::maximum_size() >= size)`.]]
-[[Effects:] [Allocates memory of at least `size` Bytes and stores a pointer to
+[[Effects:] [Allocates memory of at least `size` bytes and stores a pointer to
 the stack and its actual size in `sctx`. Depending on the architecture (the
 stack grows downwards/upwards) the stored address is the highest/lowest
 address of the stack.]]
@@ -176,7 +176,7 @@ must be compiled with compiler-flags
 [variablelist
 [[Preconditions:] [`traits_type::minimum_size() <= size` and
 `! traits_type::is_unbounded() && ( traits_type::maximum_size() >= size)`.]]
-[[Effects:] [Allocates memory of at least `size` Bytes and stores a pointer to
+[[Effects:] [Allocates memory of at least `size` bytes and stores a pointer to
 the stack and its actual size in `sctx`. Depending on the architecture (the
 stack grows downwards/upwards) the stored address is the highest/lowest
 address of the stack.]]

--- a/doc/stack.qbk
+++ b/doc/stack.qbk
@@ -80,8 +80,8 @@ virtual addresses are used.]
 
 [heading `void allocate( stack_context & sctx, std::size_t size)`]
 [variablelist
-[[Preconditions:] [`traits_type::minimum:size() <= size` and
-`! traits_type::is_unbounded() && ( traits_type::maximum:size() >= size)`.]]
+[[Preconditions:] [`traits_type::minimum_size() <= size` and
+`! traits_type::is_unbounded() && ( traits_type::maximum_size() >= size)`.]]
 [[Effects:] [Allocates memory of at least `size` Bytes and stores a pointer
 to the stack and its actual size in `sctx`. Depending
 on the architecture (the stack grows downwards/upwards) the stored address is
@@ -90,8 +90,8 @@ the highest/lowest address of the stack.]]
 
 [heading `void deallocate( stack_context & sctx)`]
 [variablelist
-[[Preconditions:] [`sctx.sp` is valid, `traits_type::minimum:size() <= sctx.size` and
-`! traits_type::is_unbounded() && ( traits_type::maximum:size() >= sctx.size)`.]]
+[[Preconditions:] [`sctx.sp` is valid, `traits_type::minimum_size() <= sctx.size` and
+`! traits_type::is_unbounded() && ( traits_type::maximum_size() >= sctx.size)`.]]
 [[Effects:] [Deallocates the stack space.]]
 ]
 
@@ -124,8 +124,8 @@ end of each stack. The memory is simply managed by `std::malloc()` and
 
 [heading `void allocate( stack_context & sctx, std::size_t size)`]
 [variablelist
-[[Preconditions:] [`traits_type::minimum:size() <= size` and
-`! traits_type::is_unbounded() && ( traits_type::maximum:size() >= size)`.]]
+[[Preconditions:] [`traits_type::minimum_size() <= size` and
+`! traits_type::is_unbounded() && ( traits_type::maximum_size() >= size)`.]]
 [[Effects:] [Allocates memory of at least `size` Bytes and stores a pointer to
 the stack and its actual size in `sctx`. Depending on the architecture (the
 stack grows downwards/upwards) the stored address is the highest/lowest
@@ -134,8 +134,8 @@ address of the stack.]]
 
 [heading `void deallocate( stack_context & sctx)`]
 [variablelist
-[[Preconditions:] [`sctx.sp` is valid, `traits_type::minimum:size() <= sctx.size` and
-`! traits_type::is_unbounded() && ( traits_type::maximum:size() >= sctx.size)`.]]
+[[Preconditions:] [`sctx.sp` is valid, `traits_type::minimum_size() <= sctx.size` and
+`! traits_type::is_unbounded() && ( traits_type::maximum_size() >= sctx.size)`.]]
 [[Effects:] [Deallocates the stack space.]]
 ]
 
@@ -174,8 +174,8 @@ must be compiled with compiler-flags
 
 [heading `void allocate( stack_context & sctx, std::size_t size)`]
 [variablelist
-[[Preconditions:] [`traits_type::minimum:size() <= size` and
-`! traits_type::is_unbounded() && ( traits_type::maximum:size() >= size)`.]]
+[[Preconditions:] [`traits_type::minimum_size() <= size` and
+`! traits_type::is_unbounded() && ( traits_type::maximum_size() >= size)`.]]
 [[Effects:] [Allocates memory of at least `size` Bytes and stores a pointer to
 the stack and its actual size in `sctx`. Depending on the architecture (the
 stack grows downwards/upwards) the stored address is the highest/lowest
@@ -184,8 +184,8 @@ address of the stack.]]
 
 [heading `void deallocate( stack_context & sctx)`]
 [variablelist
-[[Preconditions:] [`sctx.sp` is valid, `traits_type::minimum:size() <= sctx.size` and
-`! traits_type::is_unbounded() && ( traits_type::maximum:size() >= sctx.size)`.]]
+[[Preconditions:] [`sctx.sp` is valid, `traits_type::minimum_size() <= sctx.size` and
+`! traits_type::is_unbounded() && ( traits_type::maximum_size() >= sctx.size)`.]]
 [[Effects:] [Deallocates the stack space.]]
 ]
 

--- a/doc/symmetric.qbk
+++ b/doc/symmetric.qbk
@@ -428,7 +428,7 @@ to another symmetric coroutine. Parameter `x` is passed as value into `other`'s 
 [variablelist
 [[Preconditions:] [`*this` is not a __not_a_coro__.]]
 [[Returns:] [Returns data transferred from coroutine-function via
-__push_coro_op__.]]
+__call_coro_op__.]]
 [[Throws:] [`invalid_result`]]
 ]
 

--- a/doc/symmetric.qbk
+++ b/doc/symmetric.qbk
@@ -161,7 +161,7 @@ pending __forced_unwind__ exception.]
             // possibly not re-throw pending exception
         }
 
-[important Do not jump from inside a catch block and than re-throw the
+[important Do not jump from inside a catch block and then re-throw the
 exception in another execution context.]
 
 


### PR DESCRIPTION
Nothing major, just typos. I used `grep` and manual replacement to fix duplicate typos. Two of these typos also appear in Boost.Context; see this PR: https://github.com/boostorg/context/pull/18

I don't think that I'll spot more typos soon. If I do, I'll behave like the Nagle's algorithm and will *not* open another pull request.