### PR TITLE
Inheriting std::iterator is deprecated in C++17

### DIFF
--- a/include/boost/coroutine/asymmetric_coroutine.hpp
+++ b/include/boost/coroutine/asymmetric_coroutine.hpp
@@ -152,12 +152,18 @@ public:
         return * this;
     }
 
-    class iterator : public std::iterator< std::output_iterator_tag, void, void, void, void >
+    class iterator
     {
     private:
        push_coroutine< Arg >    *   c_;
 
     public:
+        typedef std::output_iterator_tag iterator_category;
+        typedef void value_type;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
+
         iterator() :
            c_( 0)
         {}
@@ -291,12 +297,18 @@ public:
         return * this;
     }
 
-    class iterator : public std::iterator< std::output_iterator_tag, void, void, void, void >
+    class iterator
     {
     private:
        push_coroutine< Arg & >  *   c_;
 
     public:
+        typedef std::output_iterator_tag iterator_category;
+        typedef void value_type;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
+
         iterator() :
            c_( 0)
         {}
@@ -725,7 +737,7 @@ public:
         return impl_->get();
     }
 
-    class iterator : public std::iterator< std::input_iterator_tag, typename remove_reference< R >::type >
+    class iterator
     {
     private:
         pull_coroutine< R > *   c_;
@@ -754,8 +766,14 @@ public:
         }
 
     public:
-        typedef typename iterator::pointer      pointer_t;
-        typedef typename iterator::reference    reference_t;
+        typedef std::input_iterator_tag iterator_category;
+        typedef typename remove_reference< R >::type value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef value_type * pointer;
+        typedef value_type & reference;
+
+        typedef pointer   pointer_t;
+        typedef reference reference_t;
 
         iterator() :
             c_( 0), val_( 0)
@@ -808,7 +826,7 @@ public:
         }
     };
 
-    class const_iterator : public std::iterator< std::input_iterator_tag, const typename remove_reference< R >::type >
+    class const_iterator
     {
     private:
         pull_coroutine< R > *   c_;
@@ -837,8 +855,14 @@ public:
         }
 
     public:
-        typedef typename const_iterator::pointer      pointer_t;
-        typedef typename const_iterator::reference    reference_t;
+        typedef std::input_iterator_tag iterator_category;
+        typedef const typename remove_reference< R >::type value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef value_type * pointer;
+        typedef value_type & reference;
+
+        typedef pointer   pointer_t;
+        typedef reference reference_t;
 
         const_iterator() :
             c_( 0), val_( 0)
@@ -1181,7 +1205,7 @@ public:
     R & get() const
     { return impl_->get(); }
 
-    class iterator : public std::iterator< std::input_iterator_tag, typename remove_reference< R >::type >
+    class iterator
     {
     private:
         pull_coroutine< R & >   *   c_;
@@ -1210,8 +1234,14 @@ public:
         }
 
     public:
-        typedef typename iterator::pointer      pointer_t;
-        typedef typename iterator::reference    reference_t;
+        typedef std::input_iterator_tag iterator_category;
+        typedef typename remove_reference< R >::type value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef value_type * pointer;
+        typedef value_type & reference;
+
+        typedef pointer   pointer_t;
+        typedef reference reference_t;
 
         iterator() :
             c_( 0), val_( 0)
@@ -1264,7 +1294,7 @@ public:
         }
     };
 
-    class const_iterator : public std::iterator< std::input_iterator_tag, const typename remove_reference< R >::type >
+    class const_iterator
     {
     private:
         pull_coroutine< R & >   *   c_;
@@ -1293,8 +1323,14 @@ public:
         }
 
     public:
-        typedef typename const_iterator::pointer      pointer_t;
-        typedef typename const_iterator::reference    reference_t;
+        typedef std::input_iterator_tag iterator_category;
+        typedef const typename remove_reference< R >::type value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef value_type * pointer;
+        typedef value_type & reference;
+
+        typedef pointer   pointer_t;
+        typedef reference reference_t;
 
         const_iterator() :
             c_( 0), val_( 0)


### PR DESCRIPTION
Therefore replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>