### PR TITLE
fixed example: iterate all left items

### DIFF
--- a/example/symmetric/merge_arrays.cpp
+++ b/example/symmetric/merge_arrays.cpp
@@ -30,7 +30,7 @@ private:
             to_.push_back(from[idx++]);
         }
         while ( to_.size() < max_)
-            to_.push_back( other->from[other->idx]); 
+            to_.push_back( other->from[other->idx++]); 
     }
 
     merger( merger const&);


### PR DESCRIPTION
Items was not iterated when several items left in another source while current source has ended.

a : 1 5 6 10 
b : 2 4 7 8 9 **13 15 17** 
c : 1 2 4 5 6 7 8 9 10 **13 13 13** 

fixed to 

a : 1 5 6 10 
b : 2 4 7 8 9 **13 15 17** 
c : 1 2 4 5 6 7 8 9 10 **13 15 17** 