### PR TITLE
Fix Windows dll-interface compilation warnings:

### DIFF
--- a/include/boost/coroutine/detail/preallocated.hpp
+++ b/include/boost/coroutine/detail/preallocated.hpp
@@ -22,7 +22,7 @@ namespace boost {
 namespace coroutines {
 namespace detail {
 
-struct preallocated {
+struct BOOST_COROUTINES_DECL preallocated {
     void        *   sp;
     std::size_t     size;
     stack_context   sctx;

--- a/include/boost/coroutine/stack_context.hpp
+++ b/include/boost/coroutine/stack_context.hpp
@@ -21,7 +21,7 @@ namespace boost {
 namespace coroutines {
 
 #if defined(BOOST_USE_SEGMENTED_STACKS)
-struct stack_context
+struct BOOST_COROUTINES_DECL stack_context
 {
     typedef void *  segments_context[BOOST_CONTEXT_SEGMENTS];
 
@@ -40,7 +40,7 @@ struct stack_context
     {}
 };
 #else
-struct stack_context
+struct BOOST_COROUTINES_DECL stack_context
 {
     std::size_t             size;
     void                *   sp;


### PR DESCRIPTION
* Add BOOST_COROUTINES_DECL where needed

The resolves warning C4251:

"...needs to have dll-interface to be used by clients of class..."