### PR TITLE
Remove linking with Boost.System

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,7 +11,6 @@ import toolset ;
 project boost/coroutine
     : requirements
       <library>/boost/context//boost_context
-      <library>/boost/system//boost_system
       <library>/boost/thread//boost_thread
       <toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
@@ -40,7 +39,6 @@ lib boost_coroutine
       exceptions.cpp
       stack_traits_sources
     : <link>shared:<library>../../context/build//boost_context
-      <link>shared:<library>../../system/build//boost_system
       <link>shared:<library>../../thread/build//boost_thread
     ;
 


### PR DESCRIPTION
Since Boost.System is header-only now, no need to link with the library.