### PR TITLE
Split stack flag

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,8 +12,8 @@ project boost/coroutine
     : requirements
       <library>/boost/context//boost_context
       <library>/boost/thread//boost_thread
-      <toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
-      <toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
+      <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
+      <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <toolset>clang,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <toolset>clang,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <link>shared:<define>BOOST_COROUTINES_DYN_LINK=1

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -19,8 +19,8 @@ project boost/coroutine/test
       <library>/boost/coroutine//boost_coroutine
       <library>/boost/program_options//boost_program_options
       <library>/boost/test///boost_unit_test_framework
-      <toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
-      <toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
+      <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
+      <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <toolset>clang,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <toolset>clang,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <link>static


### PR DESCRIPTION
PR related to issue https://github.com/boostorg/coroutine/issues/51.

Flag -fsplit-stack is only available on Linux according error message and documentation.