### PR TITLE
Fix stack unwinding example

### DIFF
--- a/doc/asymmetric.qbk
+++ b/doc/asymmetric.qbk
@@ -276,7 +276,7 @@ After unwinding, a __coro__ is complete.
             boost::coroutines::asymmetric_coroutine<void>::push_type sink(
                 [&](boost::coroutines::asymmetric_coroutine<void>::pull_type& source){
                     X x;
-                    for(int=0;;++i){
+                    for(int i=0;;++i){
                         std::cout<<"fn(): "<<i<<std::endl;
                         // transfer execution control back to main()
                         source();
@@ -299,7 +299,6 @@ After unwinding, a __coro__ is complete.
             fn(): 2
             fn(): 3
             fn(): 4
-            fn(): 5
             sink is complete: false
             ~X()
 


### PR DESCRIPTION
- missing for loop variable
- matching the number of  sink() and output