### PR TITLE
Cease dependence on Thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,6 @@ target_link_libraries(boost_coroutine
     Boost::throw_exception
     Boost::type_traits
     Boost::utility
-  PRIVATE
-    Boost::thread
 )
 
 target_compile_definitions(boost_coroutine

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,7 +11,6 @@ import toolset ;
 project boost/coroutine
     : requirements
       <library>/boost/context//boost_context
-      <library>/boost/thread//boost_thread
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <toolset>clang,<segmented-stacks>on:<cxxflags>-fsplit-stack
@@ -39,7 +38,6 @@ lib boost_coroutine
       exceptions.cpp
       stack_traits_sources
     : <link>shared:<library>../../context/build//boost_context
-      <link>shared:<library>../../thread/build//boost_thread
     ;
 
 boost-install boost_coroutine ;

--- a/src/windows/stack_traits.cpp
+++ b/src/windows/stack_traits.cpp
@@ -20,7 +20,6 @@ extern "C" {
 
 #include <boost/assert.hpp>
 #include <boost/coroutine/detail/config.hpp>
-#include <boost/thread.hpp>
 
 #include <boost/coroutine/stack_context.hpp>
 
@@ -44,25 +43,11 @@ extern "C" {
 
 namespace {
 
-void system_info_( SYSTEM_INFO * si)
-{ ::GetSystemInfo( si); }
-
-SYSTEM_INFO system_info()
-{
-    static SYSTEM_INFO si;
-    static boost::once_flag flag;
-    boost::call_once( flag, static_cast< void(*)( SYSTEM_INFO *) >( system_info_), & si);
-    return si;
-}
-
 std::size_t pagesize()
-{ return static_cast< std::size_t >( system_info().dwPageSize); }
-
-std::size_t page_count( std::size_t stacksize)
 {
-    return static_cast< std::size_t >(
-        std::floor(
-            static_cast< float >( stacksize) / pagesize() ) );
+    SYSTEM_INFO si;
+    ::GetSystemInfo(&si);
+    return static_cast< std::size_t >( si.dwPageSize );
 }
 
 }
@@ -78,7 +63,10 @@ stack_traits::is_unbounded() BOOST_NOEXCEPT
 
 std::size_t
 stack_traits::page_size() BOOST_NOEXCEPT
-{ return pagesize(); }
+{
+    static std::size_t size = pagesize();
+    return size;
+}
 
 std::size_t
 stack_traits::default_size() BOOST_NOEXCEPT


### PR DESCRIPTION
On C++11 static local variables are initialized in thread-safe manner, but even on C++03 it should not be a problem because in our case variables are of trivial types, which means double initialization is not an issue, and they are initialized with the same value in every thread.