### PR TITLE
Suppressing -Wsign-conversion warnings

### DIFF
--- a/src/posix/stack_traits.cpp
+++ b/src/posix/stack_traits.cpp
@@ -35,7 +35,7 @@ namespace {
 std::size_t pagesize()
 {
     // conform to POSIX.1-2001
-    return ::sysconf( _SC_PAGESIZE);
+    return static_cast<std::size_t>( ::sysconf( _SC_PAGESIZE) );
 }
 
 rlim_t stacksize_limit_()
@@ -86,7 +86,7 @@ stack_traits::default_size() BOOST_NOEXCEPT
 
 std::size_t
 stack_traits::minimum_size() BOOST_NOEXCEPT
-{ return SIGSTKSZ; }
+{ return static_cast<std::size_t>( SIGSTKSZ ); }
 
 std::size_t
 stack_traits::maximum_size() BOOST_NOEXCEPT


### PR DESCRIPTION
Casting them out will fix the problem easily. I've also opened a [pull request](https://github.com/boostorg/context/pull/244) for [Boost::const](https://github.com/boostorg/context/tree/develop) warnings as well.

g++ (GCC) 13.2.1 20230801

```c++
[17/27] Building CXX object _deps/boost_context-build/CMakeFiles/boost_context.dir/src/posix/stack_traits.cpp.o
/webpp/build-dev-clang/_deps/boost_context-src/src/posix/stack_traits.cpp:42:12: warning: implicit conversion changes signedness: 'long' to 'std::size_t' (aka 'unsigned long') [-Wsign-conversion]
    return ::sysconf( _SC_PAGESIZE);
    ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~
/webpp/build-dev-clang/_deps/boost_context-src/src/posix/stack_traits.cpp:80:12: warning: implicit conversion changes signedness: 'long' to 'std::size_t' (aka 'unsigned long') [-Wsign-conversion]
    return MINSIGSTKSZ;
    ~~~~~~ ^~~~~~~~~~~
/usr/include/bits/sigstksz.h:32:22: note: expanded from macro 'MINSIGSTKSZ'
# define MINSIGSTKSZ SIGSTKSZ
                     ^~~~~~~~
/usr/include/bits/sigstksz.h:28:19: note: expanded from macro 'SIGSTKSZ'
# define SIGSTKSZ sysconf (_SC_SIGSTKSZ)
                  ^~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
[19/27] Building CXX object _deps/boost_coroutine-build/CMakeFiles/boost_coroutine.dir/src/posix/stack_traits.cpp.o
/webpp/build-dev-clang/_deps/boost_coroutine-src/src/posix/stack_traits.cpp:38:12: warning: implicit conversion changes signedness: 'long' to 'std::size_t' (aka 'unsigned long') [-Wsign-conversion]
    return ::sysconf( _SC_PAGESIZE);
    ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~
/webpp/build-dev-clang/_deps/boost_coroutine-src/src/posix/stack_traits.cpp:89:10: warning: implicit conversion changes signedness: 'long' to 'std::size_t' (aka 'unsigned long') [-Wsign-conversion]
{ return SIGSTKSZ; }
  ~~~~~~ ^~~~~~~~
/usr/include/bits/sigstksz.h:28:19: note: expanded from macro 'SIGSTKSZ'
# define SIGSTKSZ sysconf (_SC_SIGSTKSZ)
                  ^~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```