### PR TITLE
Use BOOST_VERIFY instead of conditional BOOST_ASSERT

### DIFF
--- a/include/boost/coroutine/posix/protected_stack_allocator.hpp
+++ b/include/boost/coroutine/posix/protected_stack_allocator.hpp
@@ -65,12 +65,7 @@ struct basic_protected_stack_allocator
         if ( MAP_FAILED == limit) throw std::bad_alloc();
 
         // conforming to POSIX.1-2001
-#if defined(BOOST_DISABLE_ASSERTS)
-        ::mprotect( limit, traits_type::page_size(), PROT_NONE);
-#else
-        const int result( ::mprotect( limit, traits_type::page_size(), PROT_NONE) );
-        BOOST_ASSERT( 0 == result);
-#endif
+        BOOST_VERIFY( 0 == ::mprotect( limit, traits_type::page_size(), PROT_NONE));
 
         ctx.size = size_;
         ctx.sp = static_cast< char * >( limit) + ctx.size;

--- a/include/boost/coroutine/windows/protected_stack_allocator.hpp
+++ b/include/boost/coroutine/windows/protected_stack_allocator.hpp
@@ -52,14 +52,8 @@ struct basic_protected_stack_allocator
         if ( ! limit) throw std::bad_alloc();
 
         DWORD old_options;
-#if defined(BOOST_DISABLE_ASSERTS)
-        ::VirtualProtect(
-            limit, traits_type::page_size(), PAGE_READWRITE | PAGE_GUARD /*PAGE_NOACCESS*/, & old_options);
-#else
-        const BOOL result = ::VirtualProtect(
-            limit, traits_type::page_size(), PAGE_READWRITE | PAGE_GUARD /*PAGE_NOACCESS*/, & old_options);
-        BOOST_ASSERT( FALSE != result);
-#endif
+        BOOST_VERIFY( FALSE != ::VirtualProtect(
+            limit, traits_type::page_size(), PAGE_READWRITE | PAGE_GUARD /*PAGE_NOACCESS*/, & old_options));
 
         ctx.size = size_;
         ctx.sp = static_cast< char * >( limit) + ctx.size;


### PR DESCRIPTION
This change
- reduces complexity of the code in Boost.Coroutine due to the elimination of preprocessor conditionals
- removes code duplication
- prevents a warning (on some compilers) in case `BOOST_DISABLE_ASSERTS` is not defined, but `NDEBUG` is defined