### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,18 +5,20 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/context//boost_context
+    /boost/core//boost_core
+    /boost/exception//boost_exception
+    /boost/move//boost_move
+    /boost/system//boost_system
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/coroutine
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/context//boost_context
-        <library>/boost/core//boost_core
-        <library>/boost/exception//boost_exception
-        <library>/boost/move//boost_move
-        <library>/boost/system//boost_system
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
@@ -28,3 +30,4 @@ explicit
 call-if : boost-library coroutine
     : install boost_coroutine
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,30 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/coroutine
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/context//boost_context
+        <source>/boost/core//boost_core
+        <source>/boost/exception//boost_exception
+        <source>/boost/move//boost_move
+        <source>/boost/system//boost_system
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_coroutine : build//boost_coroutine ]
+    [ alias all : boost_coroutine test ]
+    ;
+
+call-if : boost-library coroutine
+    : install boost_coroutine
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,16 +7,16 @@ import project ;
 
 project /boost/coroutine
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/context//boost_context
-        <source>/boost/core//boost_core
-        <source>/boost/exception//boost_exception
-        <source>/boost/move//boost_move
-        <source>/boost/system//boost_system
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/context//boost_context
+        <library>/boost/core//boost_core
+        <library>/boost/exception//boost_exception
+        <library>/boost/move//boost_move
+        <library>/boost/system//boost_system
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/coroutine

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/coroutine
     : common-requirements

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,7 +8,7 @@ import feature ;
 import modules ;
 import toolset ;
 
-project boost/coroutine
+project
     : requirements
       <library>/boost/context//boost_context
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
@@ -37,7 +37,5 @@ lib boost_coroutine
     : detail/coroutine_context.cpp
       exceptions.cpp
       stack_traits_sources
-    : <link>shared:<library>../../context/build//boost_context
+    : <link>shared:<library>/boost/context//boost_context
     ;
-
-boost-install boost_coroutine ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -9,6 +9,7 @@ import modules ;
 import toolset ;
 
 project
+    : common-requirements <library>$(boost_dependencies)
     : requirements
       <library>/boost/context//boost_context
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -7,6 +7,8 @@
 import feature ;
 import modules ;
 import toolset ;
+import-search /boost/context ;
+import boost-context-features ;
 
 project
     : common-requirements <library>$(boost_dependencies)

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -19,6 +19,7 @@ project
       <define>BOOST_COROUTINES_SOURCE
     : usage-requirements
       <link>shared:<define>BOOST_COROUTINES_DYN_LINK=1
+      <define>BOOST_COROUTINES_NO_LIB=1
     : source-location ../src
     ;
 

--- a/example/asymmetric/Jamfile.v2
+++ b/example/asymmetric/Jamfile.v2
@@ -14,7 +14,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine/example/asymmetric
+project
     : requirements
       <library>/boost/context//boost_context
       <library>/boost/coroutine//boost_coroutine

--- a/example/symmetric/Jamfile.v2
+++ b/example/symmetric/Jamfile.v2
@@ -14,7 +14,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine/example/symmetric
+project
     : requirements
       <library>/boost/context//boost_context
       <library>/boost/coroutine//boost_coroutine

--- a/performance/asymmetric/Jamfile.v2
+++ b/performance/asymmetric/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine/performance/asymmetric
+project
     : requirements
       <library>/boost/chrono//boost_chrono
       <library>/boost/context//boost_context

--- a/performance/asymmetric/segmented/Jamfile.v2
+++ b/performance/asymmetric/segmented/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine/performance/segmented
+project
     : requirements
       <library>/boost/chrono//boost_chrono
       <library>/boost/context//boost_context

--- a/performance/symmetric/Jamfile.v2
+++ b/performance/symmetric/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine/performance/symmetric
+project
     : requirements
       <library>/boost/chrono//boost_chrono
       <library>/boost/context//boost_context

--- a/performance/symmetric/segmented/Jamfile.v2
+++ b/performance/symmetric/segmented/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine/performance/segmented
+project
     : requirements
       <library>/boost/chrono//boost_chrono
       <library>/boost/context//boost_context

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,12 +13,13 @@ import os ;
 import testing ;
 import toolset ;
 
-project boost/coroutine/test
+project
     : requirements
       <library>/boost/context//boost_context
       <library>/boost/coroutine//boost_coroutine
+      <library>/boost/foreach//boost_foreach
       <library>/boost/program_options//boost_program_options
-      <library>/boost/test///boost_unit_test_framework
+      <library>/boost/test//boost_unit_test_framework
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS
       <toolset>clang,<segmented-stacks>on:<cxxflags>-fsplit-stack


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.