### PR TITLE
Fix exception include

### DIFF
--- a/include/boost/coroutine/detail/pull_coroutine_object.hpp
+++ b/include/boost/coroutine/detail/pull_coroutine_object.hpp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
+#include <exception>
 
 #ifndef BOOST_COROUTINES_DETAIL_PULL_COROUTINE_OBJECT_H
 #define BOOST_COROUTINES_DETAIL_PULL_COROUTINE_OBJECT_H
@@ -121,7 +122,7 @@ public:
         { throw; }
 #endif
         catch (...)
-        { base_t::except_ = current_exception(); }
+        { base_t::except_ = std::current_exception(); }
 
         base_t::flags_ |= flag_complete;
         base_t::flags_ &= ~flag_running;
@@ -208,7 +209,7 @@ public:
         { throw; }
 #endif
         catch (...)
-        { base_t::except_ = current_exception(); }
+        { base_t::except_ = std::current_exception(); }
 
         base_t::flags_ |= flag_complete;
         base_t::flags_ &= ~flag_running;
@@ -295,7 +296,7 @@ public:
         { throw; }
 #endif
         catch (...)
-        { base_t::except_ = current_exception(); }
+        { base_t::except_ = std::current_exception(); }
 
         base_t::flags_ |= flag_complete;
         base_t::flags_ &= ~flag_running;

--- a/include/boost/coroutine/detail/push_coroutine_object.hpp
+++ b/include/boost/coroutine/detail/push_coroutine_object.hpp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
+#include <exception>
 
 #ifndef BOOST_COROUTINES_DETAIL_PUSH_COROUTINE_OBJECT_H
 #define BOOST_COROUTINES_DETAIL_PUSH_COROUTINE_OBJECT_H
@@ -133,7 +134,7 @@ public:
         { throw; }
 #endif
         catch (...)
-        { base_t::except_ = current_exception(); }
+        { base_t::except_ = std::current_exception(); }
 
         base_t::flags_ |= flag_complete;
         base_t::flags_ &= ~flag_running;
@@ -220,7 +221,7 @@ public:
         { throw; }
 #endif
         catch (...)
-        { base_t::except_ = current_exception(); }
+        { base_t::except_ = std::current_exception(); }
 
         base_t::flags_ |= flag_complete;
         base_t::flags_ &= ~flag_running;
@@ -307,7 +308,7 @@ public:
         { throw; }
 #endif
         catch (...)
-        { base_t::except_ = current_exception(); }
+        { base_t::except_ = std::current_exception(); }
 
         base_t::flags_ |= flag_complete;
         base_t::flags_ &= ~flag_running;


### PR DESCRIPTION
replace
	current_exception()
with
	std::current_exception()

and
 #include <exception>

to bring the symbol into scope.

References:

https://en.cppreference.com/w/cpp/error/current_exception